### PR TITLE
fix(versions): update ryandawsonuk/jhipster-sample-app versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM openjdk:8-jdk
 ADD . /code/
 RUN echo '{ "allow_root": true }' > /root/.bowerrc && \
     rm -Rf /code/target /code/node_modules && \
@@ -6,7 +6,7 @@ RUN echo '{ "allow_root": true }' > /root/.bowerrc && \
     ./mvnw clean package -Pprod -DskipTests && \
     mv /code/target/*.war /app.war
 
-FROM openjdk:8-jre-alpine
+FROM openjdk:8-jdk
 ENV SPRING_OUTPUT_ANSI_ENABLED=ALWAYS \
     JHIPSTER_SLEEP=0 \
     JAVA_OPTS=""

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "core-js": "2.5.7",
     "moment": "2.22.2",
     "ng-jhipster": "0.5.4",
-    "ngx-cookie": "2.0.1",
+    "ngx-cookie": "2.0.2",
     "ngx-infinite-scroll": "6.0.1",
     "ngx-webstorage": "2.0.1",
     "reflect-metadata": "0.1.12",

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <jhipster-dependencies.version>2.0.28</jhipster-dependencies.version>
         <!-- The spring-boot version should match the one managed by
         https://mvnrepository.com/artifact/io.github.jhipster/jhipster-dependencies/${jhipster-dependencies.version} -->
-        <spring-boot.version>2.0.6.RELEASE</spring-boot.version>
+        <spring-boot.version>2.1.0.RELEASE</spring-boot.version>
         <!-- The hibernate version should match the one managed by
         https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies/${spring-boot.version} -->
         <hibernate.version>5.2.17.Final</hibernate.version>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.springframework.boot:spring-boot-starter-data-jpa` to: `2.1.0.RELEASE`